### PR TITLE
カラーパレットの設定

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,18 +1,31 @@
 /** @type {import('tailwindcss').Config} */
+const colors = require("tailwindcss/colors");
+
 module.exports = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     extend: {
       backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
+        "gradient-conic":
+          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+      },
+      colors: {
+        main: "#333", // メインテキスト
+        sub: "#303030", // サブテキスト
+        "amatech-log": "#3DAAFC", // あまてくロゴカラー
+        title: "#252D58", // タイトル
+        "sub-title": "#A9C0CB", // サブタイトル: タイトル下の日本語訳
+        "background-object": "#D6EAF3", // 背景オブジェクト
+        background: "#F0FAFF", // 背景
+        gray: "#AAAAAA", // グレーテキスト
+        white: colors.white,
       },
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## 内容
- [x] figmaのカラースタイルに沿って、カラーパレットの設定

## 設定方法
``` 
./tailwind.config.js
theme → extend → colors
```

## カラーの使用方法
```
<{タグ} className="text-{カラー名}" >hoge</{タグ}>
```

## その他
VSCodeの拡張機能に[Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)があるので、これをインストールすることでcssの補完をしてくれます