### PR TITLE
chore: fixed build error for storybook

### DIFF
--- a/src/components/Member/list.tsx
+++ b/src/components/Member/list.tsx
@@ -7,21 +7,22 @@ type MemberListProps = {
 };
 
 export const MemberList = ({ members }: MemberListProps) => {
+  // members.contentsがundefinedの場合は空の配列を返す
+  const contents = members?.contents ?? [];
   return (
     <div className="flex flex-col items-center space-y-12 sm:flex-row sm:space-y-0 sm:space-x-12">
-      {members &&
-        members?.contents.map((member: MembersType, index: number) => (
-          <Member
-            key={index}
-            imageUrl={member.imageUrl ? member.imageUrl.url : ""}
-            name={member.name}
-            grade={member.age.join(", ")}
-            role={member.role.join(", ")}
-            github={member.github}
-            twitter={""}
-            instagram={""}
-          />
-        ))}
+      {contents.map((member: MembersType, index: Key) => (
+        <Member
+          key={index}
+          imageUrl={member.imageUrl ? member.imageUrl.url : ""}
+          name={member.name}
+          grade={member.age.join(", ")}
+          role={member.role.join(", ")}
+          github={member.github}
+          twitter={""}
+          instagram={""}
+        />
+      ))}
     </div>
   );
 };

--- a/src/components/Sponsors/SponsorLogoList.tsx
+++ b/src/components/Sponsors/SponsorLogoList.tsx
@@ -7,15 +7,14 @@ type SponsorListProps = {
 };
 
 export const SponsorLogoList = ({ sponsors }: SponsorListProps) => {
+  // sponsors.contentsがundefinedの場合は空の配列を返す
+  const contents = sponsors?.contents ?? [];
+
   return (
     <div className="flex flex-col sm:flex-row gap-[42px] items-center w-full">
-      {sponsors &&
-        sponsors?.contents.map((sponsor, index) => (
-          <SponsorLogo
-            key={index}
-            ImagePath={sponsor.url?.url ? sponsor.url.url : undefined}
-          />
-        ))}
+      {contents.map((sponsor, index) => (
+        <SponsorLogo key={index} ImagePath={sponsor.url?.url ?? undefined} />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## このプルリクエストの目的
配列が空の場合storybookでエラーになるので、cmsから返ってきた値が空の場合は、空配列をmapに渡す処理を追加しました。

## 変更の内容
- [] apiからのレスポンスが空の場合は、空配列にする処理を実装

## その他
